### PR TITLE
Bump hugo to 0.124.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 # https://github.com/jakejarvis/hugo-docker
-FROM ghcr.io/jakejarvis/hugo-extended:0.111.3
+FROM ghcr.io/jakejarvis/hugo-extended:0.124.1
 
 ENTRYPOINT ["hugo"]

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: "Hugo as an action, with extended support and legacy versions"
 author: jakejarvis
 runs:
   using: docker
-  image: docker://ghcr.io/jakejarvis/hugo-extended:0.111.3
+  image: docker://ghcr.io/jakejarvis/hugo-extended:0.124.1
 branding:
   icon: edit
   color: gray-dark


### PR DESCRIPTION
Convenience bump as the theme I use (soho)  Relies on hugo.IsServer which is new.